### PR TITLE
Remove Warnings / Make the page work / Add Beta stuff

### DIFF
--- a/index.php
+++ b/index.php
@@ -287,7 +287,7 @@ if (BY_VERSION === true) {
   $latest_builds['version'] = 'latest';
   unset($latest_builds['build']);
 
-  foreach ($products_by_major_version as &$p) {
+  foreach ($products_by_major_version as $k => &$p) {
     if ($p['has_build']) {
       $recent_builds_data['title'] = '2.0 Recent Builds';
       array_unshift($p['releases'], $latest_builds);

--- a/index.php
+++ b/index.php
@@ -339,6 +339,13 @@ foreach($products[0]['releases'] as $key => $release) {
   } 
 }
 
+foreach($products as $key => $product) {
+  if(preg_match('/couchbase-server-2-0-builds/', $product['id'])) {
+    $products[$key]['title'] = 'Couchbase Server 2.0 Recent Builds';
+  }
+}
+
+
 $products = array('products' => $products,
                   'staging' => (IS_LOCAL || IS_STAGING),
                   'show_next' => $show_next);
@@ -375,7 +382,7 @@ if ($mimetype === 'application/json') {
   Enterprise or Community. <a href="/couchbase-server/editions">Which one is right for me?</a></div>
 {{/multiple_products}}
 <h3{{^multiple_products}} class="step-1"{{/multiple_products}}{{#has_build}} id="recent-builds"{{/has_build}}>
-  {{title}} {{#has_build}}Recent Build{{/has_build}} Downloads</h3>
+  {{title}} Downloads</h3>
 <div class="cb-download-form">
   <form>
     <select>

--- a/index.php
+++ b/index.php
@@ -329,6 +329,16 @@ if (BY_VERSION === true) {
   $products[0]['releases'][0]['version'] = '2.0.0 recent builds';
 }
 
+// Quick hack to populate the beta releases to the top
+// This can be modified to push the final releases afterwards
+// @daschl, 2012-09-17
+foreach($products[0]['releases'] as $key => $release) {
+  if(preg_match('/beta/', $release['version'])) {
+    $beta = array_splice($products[0]['releases'], $key, 1, null);
+    array_unshift($products[0]['releases'], $beta[0]);
+  } 
+}
+
 $products = array('products' => $products,
                   'staging' => (IS_LOCAL || IS_STAGING),
                   'show_next' => $show_next);

--- a/index.php
+++ b/index.php
@@ -109,6 +109,13 @@ function collectFor($product_string, $contents) {
   $last_version = 0;
   foreach ($contents as $file) {
     $url = $file['name'];
+
+    // Don't allow funny filenames like releases/clients_$folder$
+    // @daschl, 2012-09-17
+    if(count(explode('/', $file['name'])) < 3) {
+      continue;
+    }
+
     list(, $version, $filename) = explode('/', $file['name']);
 
     if ($filename === "") continue;
@@ -145,6 +152,13 @@ function collectFor($product_string, $contents) {
     } else {
       preg_match("/([A-Za-z\-]*)([_]?(win2008)?[_\-](x86)[_]?(64)?)?[_]([0-9\.]*(-dev-preview-[0-9]|-beta)?(-([0-9]{4,5})-rel)?)[\.|_](.*)/",
         $filename, $matches);
+      
+      // If this regex didn't match too, skip the entry so that it doesn't produce warnings.
+      // @daschl, 2012-09-17
+      if(empty($matches)) {
+        continue;
+      }
+
       list(, $product, , , $arch, $bits, $version, $dev_preview, , $build, $postfix) = $matches;
 
       $dev_preview = $dev_preview ? true : false;
@@ -173,6 +187,12 @@ function collectFor($product_string, $contents) {
     $major_version = substr($version, 0, strpos($version, '.', 3));
     // PHP5.3 edition: $major_version = strstr($version, '.', true);
     $needs_tos = $major_version == 1.7;
+
+    // Initialize with a default date (kinda broken)
+    // @daschl, 2012-09-17
+    if(!isset($file['time'])) {
+      $file['time'] = time();
+    }
 
     $created = date('Y-m-d', $file['time']);
 


### PR DESCRIPTION
Hey,

this removes all the warnings and makes the page work (also for /all-downloads). $k is the key index that you need to specify in the foreach!

The other checks just prevent warnings from invalid files/filenames.

The beta-ordering should be in place, also for ?next=true.
